### PR TITLE
Fix Bug For Path Issue

### DIFF
--- a/nodeLauncher.py
+++ b/nodeLauncher.py
@@ -12,7 +12,7 @@ class NodelauncherCommand(sublime_plugin.TextCommand):
   #  p.terminate()
 
   def launch(self):
-    regx = re.compile(" ")
-    cmd = "cmd.exe /K node " + regx.sub("\ ", self.view.file_name());
+    #regx = re.compile(" ")
+    cmd = "cmd.exe /K node " +"\""+sekf.view.file_name()+"\"" #regx.sub("\ ", self.view.file_name());
     p = Popen(cmd)
     #sublime_plugin.on_query_context(self, "ctrl+o+p", sublime.OP_EQUAL, endS, true)


### PR DESCRIPTION
The default using regx for path correction. Replacing " " with "\ ". However, this is not working on my win10 desktop. I just change to string format by adding " " between path_name. It works!
